### PR TITLE
[DevOps] Adding pull-request discord-webhook github-action

### DIFF
--- a/.github/workflows/discord-pull-request-webhook.yml
+++ b/.github/workflows/discord-pull-request-webhook.yml
@@ -1,0 +1,16 @@
+name: GitHub Pull Request Opened Discord Webhook
+on:
+    pull_request:
+        types: 
+            - opened
+jobs:
+    send_message:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: appleboy/discord-action@master
+              with: 
+                webhook_id: ${{ secrets.DISCORD_GITHUB_UPDATES_WEBHOOK_ID }}
+                webhook_token: ${{ secrets.DISCORD_GITHUB_UPDATES_WEBHOOK_TOKEN }}
+                message: |
+                    ${{ github.event.pull_request.user }} just opened a pull-request.
+                    ${{ github.event.pull_request.url }}

--- a/.github/workflows/discord-pull-request-webhook.yml
+++ b/.github/workflows/discord-pull-request-webhook.yml
@@ -4,13 +4,13 @@ on:
         types: 
             - opened
 jobs:
-    send_message:
+    send_pr_message:
+        name: Send PR Message to \#github-updates
         runs-on: ubuntu-latest
         steps:
-            - uses: appleboy/discord-action@master
-              with: 
+            - uses: actions/checkout@master
+            - name: Send Default PR Message to \#github-updates
+              uses: appleboy/discord-action@master
+              with:
                 webhook_id: ${{ secrets.DISCORD_GITHUB_UPDATES_WEBHOOK_ID }}
                 webhook_token: ${{ secrets.DISCORD_GITHUB_UPDATES_WEBHOOK_TOKEN }}
-                message: |
-                    ${{ github.event.pull_request.user }} just opened a pull-request.
-                    ${{ github.event.pull_request.url }}


### PR DESCRIPTION
# Revisions
## Revision 2
- Adding prerequisite step to use `actions/checkout@master`
- Removing custom Discord message in favor of `appleboy/discord-action@master`'s default

## Revision 1
- Adding pull-request discord-webhook github-action

# Notes
- [`LetsMesh/ProjectHub` Issue #2: Github Updates in Discord](https://github.com/LetsMesh/ProjectHub/issues/2)
- Added `DISCORD_GITHUB_UPDATES_WEBHOOK_ID` and `DISCORD_GITHUB_UPDATES_WEBHOOK_TOKEN` to [`LetsMesh/Site` Actions Secrets and Variables](https://github.com/LetsMesh/Site/settings/secrets/actions)

# Testing
- ¯\\_(ツ)\_/¯
- I'm hoping this works once I create this pull-request


# References
- [GitHub Actions: Events That Trigger Workflows (`pull_request`)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
- [GitHub Marketplaces: Discord Message Notify](https://github.com/marketplace/actions/discord-message-notify)