### PR TITLE
Leaf/a1.2 upload picture buttons

### DIFF
--- a/meshapp/src/profile/profile-page.tsx
+++ b/meshapp/src/profile/profile-page.tsx
@@ -8,11 +8,13 @@ import {
   Chip,
   Divider,
   ClickAwayListener,
+  Tooltip,
 } from "@mui/material";
 
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
+import ErrorIcon from "@mui/icons-material/Error";
 
 import ProfileTextField from "./profile-textfield";
 import { Profile } from "./types/profile";
@@ -30,6 +32,22 @@ const theme = createTheme({
       fontFamily: "cocogoose",
       fontWeight: "bold",
       color: "#26383A",
+    },
+  },
+});
+
+const tooltipErrorTheme = createTheme({
+  components: {
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: "#f44336",
+          color: "#ffffff",
+        },
+        arrow: {
+          color: "#f44336",
+        },
+      },
     },
   },
 });
@@ -162,10 +180,12 @@ const ProfileHeader = (props: { name: string; pronouns: string }) => {
  */
 const ProfilePicture = (props: { image: string }) => {
   const [image, setImage] = useState(props.image);
+  const [showError, setShowError] = useState(false);
 
   const [open, setOpen] = useState(false);
   const handleClose = () => {
     setOpen(false);
+    setShowError(false);
   };
 
   return (
@@ -173,6 +193,7 @@ const ProfilePicture = (props: { image: string }) => {
       className="profile-page-picture-parent-container"
       onClick={() => {
         setOpen(!open);
+        setShowError(false);
       }}
     >
       <Box className="profile-page-picture-container">
@@ -181,7 +202,12 @@ const ProfilePicture = (props: { image: string }) => {
       <Box className="profile-page-picture-icon-container">
         <EditIcon sx={{ width: "26px", height: "26px" }} />
         {open && (
-          <ProfilePictureEdit handleClose={handleClose} setImage={setImage} />
+          <ProfilePictureEdit
+            handleClose={handleClose}
+            setImage={setImage}
+            showError={showError}
+            setShowError={setShowError}
+          />
         )}
       </Box>
     </Box>
@@ -189,7 +215,7 @@ const ProfilePicture = (props: { image: string }) => {
 };
 
 const ProfilePictureEdit = (props: any) => {
-  const { handleClose, setImage } = props;
+  const { handleClose, setImage, showError, setShowError } = props;
 
   const handleOptionClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent click from bubbling up to parent
@@ -206,8 +232,10 @@ const ProfilePictureEdit = (props: any) => {
     if (file && file.type.startsWith("image/")) {
       const url = URL.createObjectURL(file);
       setImage(url);
+      setShowError(false);
+      handleClose();
     } else {
-      console.log("Bad image!");
+      setShowError(true);
     }
   };
 
@@ -250,6 +278,26 @@ const ProfilePictureEdit = (props: any) => {
           </Typography>
           <DeleteIcon sx={{ width: "18px", height: "18px", pl: "3px" }} />
         </Grid>
+
+        {/* Conditionally render error message */}
+        {showError && (
+          <ThemeProvider theme={tooltipErrorTheme}>
+            <Tooltip
+              disableFocusListener
+              disableTouchListener
+              arrow
+              sx={{
+                position: "absolute",
+                top: "-13px",
+                left: "-13px",
+              }}
+              title={"Invalid file! Please upload an image."}
+              placement="top"
+            >
+              <ErrorIcon color="error" />
+            </Tooltip>
+          </ThemeProvider>
+        )}
       </Grid>
     </ClickAwayListener>
   );

--- a/meshapp/src/profile/profile-page.tsx
+++ b/meshapp/src/profile/profile-page.tsx
@@ -161,6 +161,8 @@ const ProfileHeader = (props: { name: string; pronouns: string }) => {
  * @param {string} props.image - A URL to user's profile image
  */
 const ProfilePicture = (props: { image: string }) => {
+  const [image, setImage] = useState(props.image);
+
   const [open, setOpen] = useState(false);
   const handleClose = () => {
     setOpen(false);
@@ -174,25 +176,39 @@ const ProfilePicture = (props: { image: string }) => {
       }}
     >
       <Box className="profile-page-picture-container">
-        <img
-          className="profile-page-picture-body"
-          src={props.image}
-          alt="profile"
-        />
+        <img className="profile-page-picture-body" src={image} alt="profile" />
       </Box>
       <Box className="profile-page-picture-icon-container">
         <EditIcon sx={{ width: "26px", height: "26px" }} />
-        {open && <ProfilePictureEdit handleClose={handleClose} />}
+        {open && (
+          <ProfilePictureEdit handleClose={handleClose} setImage={setImage} />
+        )}
       </Box>
     </Box>
   );
 };
 
 const ProfilePictureEdit = (props: any) => {
-  const { handleClose } = props;
+  const { handleClose, setImage } = props;
 
   const handleOptionClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent click from bubbling up to parent
+  };
+
+  const handleEditPicture = (event: React.MouseEvent) => {
+    event.stopPropagation(); // Prevent click from bubbling up to parent
+    const fileInput = document.getElementById("fileInput");
+    fileInput?.click(); // Trigger the file input click
+  };
+
+  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      const url = URL.createObjectURL(file);
+      setImage(url);
+    } else {
+      console.log("Bad image!");
+    }
   };
 
   return (
@@ -208,7 +224,18 @@ const ProfilePictureEdit = (props: any) => {
         }}
         onClick={handleOptionClick}
       >
-        <Grid item className="profile-page-picture-edit-section">
+        <input
+          type="file"
+          id="fileInput"
+          style={{ display: "none" }}
+          accept="image/*"
+          onChange={onFileChange}
+        />
+        <Grid
+          item
+          className="profile-page-picture-edit-section"
+          onClick={handleEditPicture}
+        >
           <Typography sx={{ fontFamily: "cocogoose", fontSize: "15px" }}>
             Edit
           </Typography>

--- a/meshapp/src/profile/profile-page.tsx
+++ b/meshapp/src/profile/profile-page.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   Box,
   Grid,
@@ -6,17 +6,10 @@ import {
   createTheme,
   ThemeProvider,
   Chip,
-  Divider,
-  ClickAwayListener,
-  Tooltip,
 } from "@mui/material";
 
-import EditIcon from "@mui/icons-material/Edit";
-import DeleteIcon from "@mui/icons-material/Delete";
-import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
-import ErrorIcon from "@mui/icons-material/Error";
-
 import ProfileTextField from "./profile-textfield";
+import ProfilePicture from "./profile-picture";
 import { Profile } from "./types/profile";
 import "./styling/profile-page.css";
 
@@ -32,22 +25,6 @@ const theme = createTheme({
       fontFamily: "cocogoose",
       fontWeight: "bold",
       color: "#26383A",
-    },
-  },
-});
-
-const tooltipErrorTheme = createTheme({
-  components: {
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          backgroundColor: "#f44336",
-          color: "#ffffff",
-        },
-        arrow: {
-          color: "#f44336",
-        },
-      },
     },
   },
 });
@@ -169,137 +146,6 @@ const ProfileHeader = (props: { name: string; pronouns: string }) => {
         </Grid>
       </Box>
     </ThemeProvider>
-  );
-};
-
-/**
- * Displays the user's profile picture.
- *
- * @param props - Properties of the component
- * @param {string} props.image - A URL to user's profile image
- */
-const ProfilePicture = (props: { image: string }) => {
-  const [image, setImage] = useState(props.image);
-  const [showError, setShowError] = useState(false);
-
-  const [open, setOpen] = useState(false);
-  const handleClose = () => {
-    setOpen(false);
-    setShowError(false);
-  };
-
-  return (
-    <Box
-      className="profile-page-picture-parent-container"
-      onClick={() => {
-        setOpen(!open);
-        setShowError(false);
-      }}
-    >
-      <Box className="profile-page-picture-container">
-        <img className="profile-page-picture-body" src={image} alt="profile" />
-      </Box>
-      <Box className="profile-page-picture-icon-container">
-        <EditIcon sx={{ width: "26px", height: "26px" }} />
-        {open && (
-          <ProfilePictureEdit
-            handleClose={handleClose}
-            setImage={setImage}
-            showError={showError}
-            setShowError={setShowError}
-          />
-        )}
-      </Box>
-    </Box>
-  );
-};
-
-const ProfilePictureEdit = (props: any) => {
-  const { handleClose, setImage, showError, setShowError } = props;
-
-  const handleOptionClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent click from bubbling up to parent
-  };
-
-  const handleEditPicture = (event: React.MouseEvent) => {
-    event.stopPropagation(); // Prevent click from bubbling up to parent
-    const fileInput = document.getElementById("fileInput");
-    fileInput?.click(); // Trigger the file input click
-  };
-
-  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file && file.type.startsWith("image/")) {
-      const url = URL.createObjectURL(file);
-      setImage(url);
-      setShowError(false);
-      handleClose();
-    } else {
-      setShowError(true);
-    }
-  };
-
-  return (
-    <ClickAwayListener onClickAway={handleClose}>
-      <Grid
-        container
-        className="profile-page-picture-edit-container"
-        direction="column"
-        justifyContent="center"
-        alignItems="center"
-        sx={{
-          padding: "0 5px",
-        }}
-        onClick={handleOptionClick}
-      >
-        <input
-          type="file"
-          id="fileInput"
-          style={{ display: "none" }}
-          accept="image/*"
-          onChange={onFileChange}
-        />
-        <Grid
-          item
-          className="profile-page-picture-edit-section"
-          onClick={handleEditPicture}
-        >
-          <Typography sx={{ fontFamily: "cocogoose", fontSize: "15px" }}>
-            Edit
-          </Typography>
-          <AddPhotoAlternateIcon
-            sx={{ width: "18px", height: "18px", pl: "5px" }}
-          />
-        </Grid>
-        <Divider sx={{ width: "100%", borderTop: "1px solid white" }} />
-        <Grid item className="profile-page-picture-delete-section">
-          <Typography sx={{ fontFamily: "cocogoose", fontSize: "13px" }}>
-            Delete
-          </Typography>
-          <DeleteIcon sx={{ width: "18px", height: "18px", pl: "3px" }} />
-        </Grid>
-
-        {/* Conditionally render error message */}
-        {showError && (
-          <ThemeProvider theme={tooltipErrorTheme}>
-            <Tooltip
-              disableFocusListener
-              disableTouchListener
-              arrow
-              sx={{
-                position: "absolute",
-                top: "-13px",
-                left: "-13px",
-              }}
-              title={"Invalid file! Please upload an image."}
-              placement="top"
-            >
-              <ErrorIcon color="error" />
-            </Tooltip>
-          </ThemeProvider>
-        )}
-      </Grid>
-    </ClickAwayListener>
   );
 };
 

--- a/meshapp/src/profile/profile-page.tsx
+++ b/meshapp/src/profile/profile-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Box,
   Grid,
@@ -6,7 +6,13 @@ import {
   createTheme,
   ThemeProvider,
   Chip,
+  Divider,
+  ClickAwayListener,
 } from "@mui/material";
+
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 
 import ProfileTextField from "./profile-textfield";
 import { Profile } from "./types/profile";
@@ -155,14 +161,70 @@ const ProfileHeader = (props: { name: string; pronouns: string }) => {
  * @param {string} props.image - A URL to user's profile image
  */
 const ProfilePicture = (props: { image: string }) => {
+  const [open, setOpen] = useState(false);
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
-    <Box className="profile-page-picture-container">
-      <img
-        className="profile-page-picture-body"
-        src={props.image}
-        alt="profile"
-      />
+    <Box
+      className="profile-page-picture-parent-container"
+      onClick={() => {
+        setOpen(!open);
+      }}
+    >
+      <Box className="profile-page-picture-container">
+        <img
+          className="profile-page-picture-body"
+          src={props.image}
+          alt="profile"
+        />
+      </Box>
+      <Box className="profile-page-picture-icon-container">
+        <EditIcon sx={{ width: "26px", height: "26px" }} />
+        {open && <ProfilePictureEdit handleClose={handleClose} />}
+      </Box>
     </Box>
+  );
+};
+
+const ProfilePictureEdit = (props: any) => {
+  const { handleClose } = props;
+
+  const handleOptionClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent click from bubbling up to parent
+  };
+
+  return (
+    <ClickAwayListener onClickAway={handleClose}>
+      <Grid
+        container
+        className="profile-page-picture-edit-container"
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        sx={{
+          padding: "0 5px",
+        }}
+        onClick={handleOptionClick}
+      >
+        <Grid item className="profile-page-picture-edit-section">
+          <Typography sx={{ fontFamily: "cocogoose", fontSize: "15px" }}>
+            Edit
+          </Typography>
+          <AddPhotoAlternateIcon
+            sx={{ width: "18px", height: "18px", pl: "5px" }}
+          />
+        </Grid>
+        <Divider sx={{ width: "100%", borderTop: "1px solid white" }} />
+        <Grid item className="profile-page-picture-delete-section">
+          <Typography sx={{ fontFamily: "cocogoose", fontSize: "13px" }}>
+            Delete
+          </Typography>
+          <DeleteIcon sx={{ width: "18px", height: "18px", pl: "3px" }} />
+        </Grid>
+      </Grid>
+    </ClickAwayListener>
   );
 };
 

--- a/meshapp/src/profile/profile-picture.tsx
+++ b/meshapp/src/profile/profile-picture.tsx
@@ -75,6 +75,10 @@ const ProfilePicture = (props: { image: string }) => {
   );
 };
 
+/**
+ * Sub-component of ProfilePicture
+ * Displays buttons that allow profile picture editing
+ */
 const ProfilePictureEdit = (props: any) => {
   const { handleClose, setImage, showError, setShowError } = props;
 

--- a/meshapp/src/profile/profile-picture.tsx
+++ b/meshapp/src/profile/profile-picture.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Grid,
+  Typography,
+  createTheme,
+  ThemeProvider,
+  Divider,
+  ClickAwayListener,
+  Tooltip,
+} from "@mui/material";
+
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
+import ErrorIcon from "@mui/icons-material/Error";
+
+import "./styling/profile-page.css";
+
+const tooltipErrorTheme = createTheme({
+  components: {
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: "#f44336",
+          color: "#ffffff",
+        },
+        arrow: {
+          color: "#f44336",
+        },
+      },
+    },
+  },
+});
+
+/**
+ * Displays the user's profile picture.
+ *
+ * @param props - Properties of the component
+ * @param {string} props.image - A URL to user's profile image
+ */
+const ProfilePicture = (props: { image: string }) => {
+  const [image, setImage] = useState(props.image);
+  const [showError, setShowError] = useState(false);
+
+  const [open, setOpen] = useState(false);
+  const handleClose = () => {
+    setOpen(false);
+    setShowError(false);
+  };
+
+  return (
+    <Box
+      className="profile-page-picture-parent-container"
+      onClick={() => {
+        setOpen(!open);
+        setShowError(false);
+      }}
+    >
+      <Box className="profile-page-picture-container">
+        <img className="profile-page-picture-body" src={image} alt="profile" />
+      </Box>
+      <Box className="profile-page-picture-icon-container">
+        <EditIcon sx={{ width: "26px", height: "26px" }} />
+        {open && (
+          <ProfilePictureEdit
+            handleClose={handleClose}
+            setImage={setImage}
+            showError={showError}
+            setShowError={setShowError}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const ProfilePictureEdit = (props: any) => {
+  const { handleClose, setImage, showError, setShowError } = props;
+
+  const handleOptionClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent click from bubbling up to parent
+  };
+
+  const handleEditPicture = (event: React.MouseEvent) => {
+    event.stopPropagation(); // Prevent click from bubbling up to parent
+    const fileInput = document.getElementById("fileInput");
+    fileInput?.click(); // Trigger the file input click
+  };
+
+  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      const url = URL.createObjectURL(file);
+      setImage(url);
+      setShowError(false);
+      handleClose();
+    } else {
+      setShowError(true);
+    }
+  };
+
+  return (
+    <ClickAwayListener onClickAway={handleClose}>
+      <Grid
+        container
+        className="profile-page-picture-edit-container"
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        sx={{
+          padding: "0 5px",
+        }}
+        onClick={handleOptionClick}
+      >
+        <input
+          type="file"
+          id="fileInput"
+          style={{ display: "none" }}
+          accept="image/*"
+          onChange={onFileChange}
+        />
+        <Grid
+          item
+          className="profile-page-picture-edit-section"
+          onClick={handleEditPicture}
+        >
+          <Typography sx={{ fontFamily: "cocogoose", fontSize: "15px" }}>
+            Edit
+          </Typography>
+          <AddPhotoAlternateIcon
+            sx={{ width: "18px", height: "18px", pl: "5px" }}
+          />
+        </Grid>
+        <Divider sx={{ width: "100%", borderTop: "1px solid white" }} />
+        <Grid item className="profile-page-picture-delete-section">
+          <Typography sx={{ fontFamily: "cocogoose", fontSize: "13px" }}>
+            Delete
+          </Typography>
+          <DeleteIcon sx={{ width: "18px", height: "18px", pl: "3px" }} />
+        </Grid>
+
+        {/* Conditionally render error message */}
+        {showError && (
+          <ThemeProvider theme={tooltipErrorTheme}>
+            <Tooltip
+              disableFocusListener
+              disableTouchListener
+              arrow
+              sx={{
+                position: "absolute",
+                top: "-13px",
+                left: "-13px",
+              }}
+              title={"Invalid file! Please upload an image."}
+              placement="top"
+            >
+              <ErrorIcon color="error" />
+            </Tooltip>
+          </ThemeProvider>
+        )}
+      </Grid>
+    </ClickAwayListener>
+  );
+};
+
+export default ProfilePicture;

--- a/meshapp/src/profile/profile-picture.tsx
+++ b/meshapp/src/profile/profile-picture.tsx
@@ -99,6 +99,9 @@ const ProfilePictureEdit = (props: any) => {
       setImage(url);
       setShowError(false);
       handleClose();
+
+      // TODO: Upload image to server via http (work here)
+      // ->
     } else {
       setShowError(true);
     }

--- a/meshapp/src/profile/styling/profile-page.css
+++ b/meshapp/src/profile/styling/profile-page.css
@@ -21,7 +21,6 @@ body {
   background-color: #f2e8de;
   height: 200px;
   display: flex;
-  justify-content: space-between;
 }
 
 .profile-page-body {
@@ -35,19 +34,77 @@ body {
   word-break: break-all;
 }
 
+.profile-page-picture-parent-container {
+  position: relative;
+  width: 250px;
+  height: 250px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
 .profile-page-picture-container {
   border-radius: 50%;
   width: 250px;
   height: 250px;
-  background-color: lightgray;
+  background-color: #f2e8de;
   overflow: hidden;
   position: relative;
-  cursor: pointer;
 }
 .profile-page-picture-body {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.profile-page-picture-icon-container {
+  position: absolute;
+  width: 35px;
+  height: 35px;
+  top: 75%;
+  left: 16px;
+  background-color: #1db272;
+  color: white;
+  padding: 5px;
+  border-radius: 25%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.profile-page-picture-edit-container {
+  position: absolute;
+  left: -100px;
+  min-width: 90px;
+  min-height: 80px;
+  border-radius: 10px;
+  background-color: #1db272;
+}
+
+.profile-page-picture-edit-container::after {
+  content: "";
+  position: absolute;
+  right: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 7px;
+  border-style: solid;
+  border-color: transparent transparent transparent #1db272;
+}
+
+.profile-page-picture-edit-section,
+.profile-page-picture-delete-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  transition: color 0.075s ease-in-out;
+}
+
+.profile-page-picture-edit-section:hover,
+.profile-page-picture-delete-section:hover {
+  color: lightgray;
 }
 
 .profile-page-roles {

--- a/meshapp/src/profile/styling/profile-page.css
+++ b/meshapp/src/profile/styling/profile-page.css
@@ -46,7 +46,7 @@ body {
   border-radius: 50%;
   width: 250px;
   height: 250px;
-  background-color: #f2e8de;
+  background-color: lightgray;
   overflow: hidden;
   position: relative;
 }


### PR DESCRIPTION
### FEATURES ###
- Adds a container for profile picture editing
  - Includes buttons for editing and deleting
- This PR only fully implements the **edit button** (delete button done in another issue)
- Error icon + tooltip appears for non-image inputs (imo underwhelming, but cba to put in a bunch of effort for the smallest of effects - can be done in the future if time allows)

### TODO ###
- Delete button (done in another issue, also my job)
- Backend-related issues for this

### NOTES ###
- I moved the profile picture-related components to its own folder to avoid bloating the main profile page file, but the profile-picture.tsx file uses the same css as profile-page.tsx. Not that big of a deal imo, but worth to put it here anyways

Closes #2