### PR TITLE
B1.5 Email Confirmation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # Django
 *.pyc
 *.sqlite3
+media

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 # Django
 *.pyc
 *.sqlite3
-media

--- a/mesh/confirmation/urls.py
+++ b/mesh/confirmation/urls.py
@@ -3,5 +3,5 @@ from . import views as confirmation_views
 
 urlpatterns = [
     path('<str:user_email>/', confirmation_views.email_confirmation, name="email_confirmation"),
-    path('<str:user_email>/<str:token>/', confirmation_views.confirm_token, name="confirm_token"),
+    path('<str:user_email>/<str:url_token>/', confirmation_views.confirm_token, name="confirm_token"),
 ]

--- a/mesh/confirmation/urls.py
+++ b/mesh/confirmation/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path, include
+from . import views as confirmation_views
+
+urlpatterns = [
+    path('<str:user_email>/', confirmation_views.email_confirmation, name="email_confirmation"),
+    path('<str:user_email>/<str:token>/', confirmation_views.confirm_token, name="confirm_token"),
+]

--- a/mesh/confirmation/views.py
+++ b/mesh/confirmation/views.py
@@ -30,11 +30,14 @@ def email_confirmation(request, user_email):
     # Prevent user from generating too many tokens/receiving too many emails
     settings_data = get_settings_data(account_id)
     
+    EMAIL_CONFIRMATION_COOLDOWN_SECONDS = 600
+    EMAIL_CONFIRMATION_COOLDOWN_MINUTES = EMAIL_CONFIRMATION_COOLDOWN_SECONDS // 60
+    
     seconds_since_last_token = calculate_timestamp_difference(settings_data["verificationToken"])
     minutes_since_last_token = seconds_since_last_token // 60
     
-    if seconds_since_last_token <= 600:
-        return HttpResponse(user_email + ": It has been " + str(minutes_since_last_token) + " minutes since last attempt at verifying email! Please try again in " + str(10 - minutes_since_last_token) + " minutes.")
+    if seconds_since_last_token <= EMAIL_CONFIRMATION_COOLDOWN_SECONDS:
+        return HttpResponse(user_email + ": It has been " + str(minutes_since_last_token) + " minutes since last attempt at verifying email! Please try again in " + str(EMAIL_CONFIRMATION_COOLDOWN_MINUTES - minutes_since_last_token) + " minutes.")
     
     # Generate a token for the user
     verification_token = generate_token_with_timestamp()

--- a/mesh/confirmation/views.py
+++ b/mesh/confirmation/views.py
@@ -1,0 +1,37 @@
+from django.http import HttpResponse
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from django.utils.html import strip_tags
+import secrets
+
+# TODO: It would likely be easier to just store the 
+# unique token generated for the user in their settings,
+# and then when they click the link sent to them we can verify
+# that the one sent to them is the same as the one stored
+# in their settings.
+
+# Generate random token for user and send confirmation email
+def email_confirmation(request, user_email):
+    # Generate a token for the user
+    confirmation_token = secrets.token_hex(16)
+
+    # Construct the confirmation URL
+    confirmation_url = request.build_absolute_uri(f"/confirmation/{user_email}/{confirmation_token}/")
+
+    # Render the email template with the confirmation URL
+    email_subject = 'Account Confirmation'
+    email_template = 'confirmation_email.html'
+    email_context = {'confirmation_url': confirmation_url}
+    email_message = render_to_string(email_template, email_context)
+    email_plain_message = strip_tags(email_message)
+
+    # Send the confirmation email
+    send_mail(email_subject, email_plain_message, 'letsmesh_testing02@outlook.com', 
+              [user_email], html_message=email_message)
+
+    return HttpResponse(user_email + ": Confirmation email sent!")
+
+# Check that the user's stored token is the same one in the URL,
+# if so, set isVerified to true.
+def confirm_token(request, user_email, token):
+    return HttpResponse(user_email + ": Email confirmation success!")

--- a/mesh/confirmation/views.py
+++ b/mesh/confirmation/views.py
@@ -8,9 +8,6 @@ from ..profiles.models import Profile
 import secrets
 import os
 import time
-from dotenv import load_dotenv
-
-load_dotenv()
 
 # Generate random token for user, store it, and send confirmation email
 # which then leads into the confirm_token function

--- a/mesh/confirmation/views.py
+++ b/mesh/confirmation/views.py
@@ -5,61 +5,82 @@ from django.utils.html import strip_tags
 from ..accounts.models import Account
 from ..accountSettings.models import Settings
 import secrets
+import os
+from dotenv import load_dotenv
 
-# Generate random token for user and send confirmation email
+load_dotenv()
+
+
+# Generate random token for user, store it, and send confirmation email
+# which then leads into the confirm_token function
 def email_confirmation(request, user_email):
-    
     # Grab account ID by user_email
     account_id = get_account_id(user_email)
 
-    # Grab settings data by account_id
-    settings_data = get_settings_data(account_id)
+    if account_id is None:
+        return HttpResponse(user_email + ": User does not exist!")
+    
+    # Grab account email verification status
     email_already_verified = get_verification_status(account_id)
 
     # Check if user email is verified yet or not
     # if so, skip generating new token
     if email_already_verified:
         return HttpResponse(user_email + ": User email already verified!")
-    
+
     # Generate a token for the user
     verification_token = secrets.token_hex(16)
-    
+
     # update the settings table with the verification_token
-    Settings.objects.filter(accountID=account_id).update(verificationToken=verification_token)
+    Settings.objects.filter(accountID=account_id).update(
+        verificationToken=verification_token
+    )
 
     # Construct the confirmation URL
-    confirmation_url = request.build_absolute_uri(f"/confirmation/{user_email}/{verification_token}/")
+    confirmation_url = request.build_absolute_uri(
+        f"/confirmation/{user_email}/{verification_token}/"
+    )
 
     # Render the email template with the confirmation URL
-    email_subject = 'Account Confirmation'
-    email_template = 'confirmation_email.html'
-    email_context = {'confirmation_url': confirmation_url}
+    email_subject = "Account Confirmation"
+    email_template = "confirmation_email.html"
+    email_context = {"confirmation_url": confirmation_url}
     email_message = render_to_string(email_template, email_context)
     email_plain_message = strip_tags(email_message)
 
+    print(os.environ.get("EMAIL_NAME"))
+
     # Send the confirmation email
-    send_mail(email_subject, email_plain_message, 'letsmesh_testing02@outlook.com', 
-              [user_email], html_message=email_message)
+    send_mail(
+        email_subject,
+        email_plain_message,
+        os.environ.get("EMAIL_NAME"),
+        [user_email],
+        html_message=email_message,
+    )
 
     return HttpResponse(user_email + ": Confirmation email sent!")
+
 
 # Check that the user's stored token is the same one in the URL,
 # if so, set isVerified to true.
 def confirm_token(request, user_email, url_token):
-
     # Grab account data by user_email
     account_id = get_account_id(user_email)
 
     # Grab settings data by the account_id
     settings_data = get_settings_data(account_id)
-    
+
     email_already_verified = get_verification_status(account_id)
 
     # Check if user email is verified yet or not
     # if so, skip updating settings table
     if email_already_verified:
-        return HttpResponse(user_email + ": Email confirmation success as user email is already verified!")
-    
+        return HttpResponse(
+            user_email
+            + ": Email confirmation success as user email is already verified!"
+        )
+
     # Grab the token stored in the database for this user
     db_token = settings_data["verificationToken"]
 
@@ -70,26 +91,44 @@ def confirm_token(request, user_email, url_token):
     else:
         return HttpResponse(user_email + ": Email confirmation failed!")
 
+
+# Note: For the Django function Model.objects.filter(...), the function
+# returns a QuerySet, which is just a set of objects (python dicts).
+# If the user has a unique email/accountID, then the user should be the only item in the set,
+# and thus will be the at the 0th index. Each function checks if the user exists.
+
 # Grab account ID by user_email
 def get_account_id(user_email):
-    
     raw_account_data = Account.objects.filter(email=user_email).values()
+    print(raw_account_data)
+    
+    if not raw_account_data:
+        return None
+
     account_data = raw_account_data[0]
+    print(account_data)
     account_id = account_data["accountID"]
 
     return account_id
 
+
 # Grab settings data by the account_id
+# settings_data is a python dict containing
+# data for each field in the Settings model
 def get_settings_data(account_id):
-    
     raw_settings_data = Settings.objects.filter(accountID=account_id).values()
+    
+    if not raw_settings_data:
+        return None
+
     settings_data = raw_settings_data[0]
 
     return settings_data
 
+
 # Returns true or false depending on if user email is already verified
 def get_verification_status(account_id):
-    settings_data = get_settings_data(account_id)
+    settings_data = get_settings_data(account_id) 
     email_verification_status = settings_data["isVerified"]
 
     return email_verification_status

--- a/mesh/confirmation/views.py
+++ b/mesh/confirmation/views.py
@@ -2,21 +2,38 @@ from django.http import HttpResponse
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
+from ..accounts.models import Account
+from ..accountSettings.models import Settings
 import secrets
-
-# TODO: It would likely be easier to just store the 
-# unique token generated for the user in their settings,
-# and then when they click the link sent to them we can verify
-# that the one sent to them is the same as the one stored
-# in their settings.
 
 # Generate random token for user and send confirmation email
 def email_confirmation(request, user_email):
+    
+    # Grab account data by user_email
+    raw_account_data = Account.objects.filter(email=user_email).values()
+    account_data = raw_account_data[0]
+    account_id = account_data["accountID"]
+    print(account_id)
+
+    # Grab settings data by the account_id
+    raw_settings_data = Settings.objects.filter(accountID=account_id).values()
+    settings_data = raw_settings_data[0]
+    email_already_verified = settings_data["isVerified"]
+    print(settings_data)
+
+    # Check if user email is verified yet or not
+    # if so, skip generating new token
+    if email_already_verified:
+        return HttpResponse(user_email + ": User email already verified!")
+    
     # Generate a token for the user
-    confirmation_token = secrets.token_hex(16)
+    verification_token = secrets.token_hex(16)
+    
+    # update the settings table with the verification_token
+    Settings.objects.filter(accountID=account_id).update(verificationToken=verification_token)
 
     # Construct the confirmation URL
-    confirmation_url = request.build_absolute_uri(f"/confirmation/{user_email}/{confirmation_token}/")
+    confirmation_url = request.build_absolute_uri(f"/confirmation/{user_email}/{verification_token}/")
 
     # Render the email template with the confirmation URL
     email_subject = 'Account Confirmation'
@@ -33,5 +50,25 @@ def email_confirmation(request, user_email):
 
 # Check that the user's stored token is the same one in the URL,
 # if so, set isVerified to true.
-def confirm_token(request, user_email, token):
-    return HttpResponse(user_email + ": Email confirmation success!")
+def confirm_token(request, user_email, url_token):
+
+    # Grab account data by user_email
+    raw_account_data = Account.objects.filter(email=user_email).values()
+    account_data = raw_account_data[0]
+    account_id = account_data["accountID"]
+
+    # Grab settings data by the account_id
+    raw_settings_data = Settings.objects.filter(accountID=account_id).values()
+    settings_data = raw_settings_data[0]
+    
+    # Grab the token stored in the database for this user
+    db_token = settings_data["verificationToken"]
+
+    # If the tokens match, then the user is verified
+    if url_token == db_token:
+        Settings.objects.filter(accountID=account_id).update(isVerified=True)
+        return HttpResponse(user_email + ": Email confirmation success!")
+    else:
+        return HttpResponse(user_email + ": Email confirmation failed!")
+
+    

--- a/mesh/settings.py
+++ b/mesh/settings.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -72,7 +75,8 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
-            os.path.join(BASE_DIR, 'meshapp/build')
+            os.path.join(BASE_DIR, 'meshapp/build'),
+            os.path.join(BASE_DIR, 'templates'),
         ],
         'APP_DIRS': True,
         'OPTIONS': {
@@ -121,6 +125,15 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+# Email handling
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.office365.com'
+EMAIL_PORT = 587
+EMAIL_USE_STARTTLS = True
+EMAIL_HOST_USER = os.environ.get('EMAIL_NAME')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_PASSWORD')
+EMAIL_USE_TLS = True
 
 
 # Internationalization

--- a/mesh/urls.py
+++ b/mesh/urls.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 from mesh.exampleapi import urls as example_urls
 from mesh.profiles import urls as profile_urls
 from mesh.accounts import urls as account
+from mesh.confirmation import urls as confirmation_urls
 
 from mesh.accounts import urls as accounts_urls
 
@@ -41,4 +42,5 @@ urlpatterns = [
     path('example/', include(example_urls)),
     path('profiles/', include(profile_urls)),
     path('accounts/', include(accounts_urls)),
+    path('confirmation/', include(confirmation_urls)),
 ]

--- a/templates/confirmation_email.html
+++ b/templates/confirmation_email.html
@@ -1,11 +1,63 @@
 <!-- confirmation_email.html -->
 <!DOCTYPE html>
-<html>
-  <body>
-    <h1>Account Confirmation</h1>
-    <p>
-      Thank you for signing up! To confirm your email, click the following link:
-    </p>
-    <a href="{{ confirmation_url }}">Confirm Email</a>
-  </body>
+<html lang="en">
+  <head>
+    <title>Mesh Account Verification</title>
+    <style type="text/css">
+      .button {
+        font-size: 14px;
+        background-color: #28a745;
+        border-radius: 0.5em;
+        display: inline-block;
+        padding: 0.75em 1.5em;
+        text-decoration: none;
+      }
+      .logo {
+        width: 120px;
+        height: auto;
+      }
+      .text {
+        color: black;
+        margin: 1em;
+        font-size: 16px;
+        line-height: 1.5em;
+        text-align: left;
+      }
+      .buttonText {
+        color: #fff;
+      }
+      .container {
+        margin: 0 auto;
+        max-width: 600px;
+        font-family: Segoe UI;
+      }
+      .content {
+        margin: 0 auto;
+        max-width: 600px;
+        padding: 0.5em 1em 0 1em;
+        border: solid 1px #dedede;
+        border-radius: 5px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <html>
+    <body>
+      <div class="container">
+        <!-- use imgur link for source until images can be uploaded to an S3 source -->
+        <img src="https://i.imgur.com/MC4Z8DN.png" class="logo" alt="Mesh Logo" />
+        <div class="content">
+          <h1>Account Confirmation</h1>
+          <div class="text">
+            <p>Hi {{name}}!</p>
+            <p>Thank you for signing up! To confirm your email, click the following link:</p>
+          </div>
+          <a target="_blank" href="{{ confirmation_url }}" class="button">
+            <span class="buttonText">Confirm Email</span>
+          </a>
+          <p>or visit: <a href="{{ confirmation_url }}">{{ confirmation_url }}</a></p>
+        </div>
+      </div>
+    </body>
+  </html>
 </html>

--- a/templates/confirmation_email.html
+++ b/templates/confirmation_email.html
@@ -1,0 +1,11 @@
+<!-- confirmation_email.html -->
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Account Confirmation</h1>
+    <p>
+      Thank you for signing up! To confirm your email, click the following link:
+    </p>
+    <a href="{{ confirmation_url }}">Confirm Email</a>
+  </body>
+</html>


### PR DESCRIPTION
Resolves issue #74 

### FEATURE
- After a user signs up, they should be redirected to `.../confirmation/<email>/,` at which point a unique 8 bit token along with the current time as an integer will be created and stored in the Settings table for their account, and a message will be displayed saying to check their email.
- A pretty email will be sent to the user containing a welcoming message and a link to actually verify their email. and when they follow it, their email will be verified and the Settings table will be updated accordingly. 
- If a user tries to request email verification again in a 10 minute window, they will be told to wait until 10 minutes have elapsed since their last attempt to verify their email.
- If a user is already verified, they will be notified and no new token will be generated.
- If a user does not exist and they attempt verification, they will be notified that the account does not exist.

### TO-DO
- Currently uses "personal" emails, which will get your account locked if sent to someone NOT on your current IP. This should likely be solved by setting up the project to use some free email sending service like Sendgrid, as outlined in issue #251.
- The pages for displaying to a user that an email has been sent to them and that their email has been verified would likely be completed with issue #64.