### PR TITLE
Leaf/f1.1 theme toggle setting ux

### DIFF
--- a/meshapp/src/Routing/MainPageRoutes.tsx
+++ b/meshapp/src/Routing/MainPageRoutes.tsx
@@ -4,12 +4,11 @@ import Login from "../home/login";
 import ForgotPassword from "../components/password-forms/forgot-password-form";
 import LoggedInHome from "../home/logged-in/LoggedInHome";
 import ProfilePage from "../profile/profile-page";
-import {
-  exampleProfile,
-} from "../profile/tests/profile-examples";
+import { exampleProfile } from "../profile/tests/profile-examples";
 import Slider from "../ProfileCardCarousel/Swiper";
 import { Routes, Route, Link } from "react-router-dom";
 import { paths } from "./RoutePaths";
+import ThemeToggleSwitch from "../theme/ThemeToggle";
 
 //contains routes for the main page
 export default function MainPageRoutes() {
@@ -27,6 +26,21 @@ export default function MainPageRoutes() {
         element={<ProfilePage {...exampleProfile} />}
       />
       <Route path={paths.profile_swipe} element={<Slider />} />
+      {/*Temporary page to hold theme toggle switch*/}
+      <Route
+        path={paths.settings}
+        element={
+          <div
+            style={{
+              display: "flex",
+              marginTop: "100px",
+              justifyContent: "center",
+            }}
+          >
+            <ThemeToggleSwitch />
+          </div>
+        }
+      />
       {/*default route*/}
       <Route path="*" element={<Nav />} />
     </Routes>
@@ -52,6 +66,7 @@ function Nav() {
       <Link to={paths.logged_in_home}>Logged In Home</Link>
       <Link to={paths.profile_page}>Profile Page</Link>
       <Link to={paths.profile_swipe}>Profile Swipe</Link>
+      <Link to={paths.settings}>Settings</Link>
     </div>
   );
 }

--- a/meshapp/src/Routing/RoutePaths.tsx
+++ b/meshapp/src/Routing/RoutePaths.tsx
@@ -9,4 +9,5 @@ export const paths = {
   logged_in_home: "/logged_in_home",
   logged_out_home: "/logged_out_home",
   sign_up: "/sign_up",
+  settings: "/settings",
 };

--- a/meshapp/src/index.tsx
+++ b/meshapp/src/index.tsx
@@ -3,15 +3,17 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import TwoFactorAuthReminders from "./two-factor-auth/two-factor-reminder";
 import AppRoutes from "./Routing/AppRoutes";
-import MainThemeProvider from "./theme/MainThemeProvider";
+import { ThemeContextProvider } from "./theme/ThemeContextProvider";
+import { MainThemeProvider } from "./theme/MainThemeProvider";
 const root = ReactDOM.createRoot(document.getElementById("root")!);
-
 root.render(
   <React.StrictMode>
-    <MainThemeProvider>
-      <TwoFactorAuthReminders />
-      <AppRoutes />
-    </MainThemeProvider>
+    <ThemeContextProvider>
+      <MainThemeProvider>
+        <TwoFactorAuthReminders />
+        <AppRoutes />
+      </MainThemeProvider>
+    </ThemeContextProvider>
   </React.StrictMode>
 );
 

--- a/meshapp/src/index.tsx
+++ b/meshapp/src/index.tsx
@@ -2,16 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import TwoFactorAuthReminders from "./two-factor-auth/two-factor-reminder";
-import MainTheme from "./theme/MainTheme";
-import { ThemeProvider } from "@emotion/react";
 import AppRoutes from "./Routing/AppRoutes";
+import MainThemeProvider from "./theme/MainThemeProvider";
 const root = ReactDOM.createRoot(document.getElementById("root")!);
+
 root.render(
   <React.StrictMode>
-    <ThemeProvider theme={MainTheme}>
+    <MainThemeProvider>
       <TwoFactorAuthReminders />
       <AppRoutes />
-    </ThemeProvider>
+    </MainThemeProvider>
   </React.StrictMode>
 );
 

--- a/meshapp/src/theme/MainTheme.tsx
+++ b/meshapp/src/theme/MainTheme.tsx
@@ -1,5 +1,4 @@
 import { PaletteMode, createTheme } from "@mui/material";
-import React from "react";
 
 //gets pallete colors and component colors based on mode
 const getDesignTokens = (mode: PaletteMode) => ({
@@ -238,9 +237,9 @@ function getComponents(mode: PaletteMode) {
   };
 }
 
-//change arg to light or dark, depending on which mode you want, to switch to that mode
-const theme = createTheme({
-  ...getDesignTokens("dark"),
-});
-
-export default theme;
+/*
+This function creates and returns theme based on input mode
+*/
+export default function getMainTheme(mode: PaletteMode) {
+  return createTheme(getDesignTokens(mode));
+}

--- a/meshapp/src/theme/MainThemeProvider.tsx
+++ b/meshapp/src/theme/MainThemeProvider.tsx
@@ -1,0 +1,22 @@
+import { ThemeProvider } from "@emotion/react";
+import getMainTheme from "./MainTheme";
+import { PaletteMode } from "@mui/material";
+
+/*
+This component returns a theme provider for light/dark mode
+*/
+export default function MainThemeProvider(props: {
+  children: React.ReactNode;
+}) {
+  //get mode from local storage
+  let storedMode = localStorage.getItem("themeMode");
+
+  //validate stored mode, if it exists and is a valid mode use it, otherwise use light mode
+  let mode: PaletteMode =
+    storedMode && (storedMode === "light" || storedMode === "dark")
+      ? storedMode
+      : "light";
+  let theme = getMainTheme(mode);
+
+  return <ThemeProvider children={props.children} theme={theme} />;
+}

--- a/meshapp/src/theme/MainThemeProvider.tsx
+++ b/meshapp/src/theme/MainThemeProvider.tsx
@@ -1,22 +1,9 @@
+import { FC, PropsWithChildren } from "react";
+import { useThemeContext } from "./ThemeContextProvider";
 import { ThemeProvider } from "@emotion/react";
-import getMainTheme from "./MainTheme";
-import { PaletteMode } from "@mui/material";
 
-/*
-This component returns a theme provider for light/dark mode
-*/
-export default function MainThemeProvider(props: {
-  children: React.ReactNode;
-}) {
-  //get mode from local storage
-  let storedMode = localStorage.getItem("themeMode");
-
-  //validate stored mode, if it exists and is a valid mode use it, otherwise use light mode
-  let mode: PaletteMode =
-    storedMode && (storedMode === "light" || storedMode === "dark")
-      ? storedMode
-      : "light";
-  let theme = getMainTheme(mode);
-
-  return <ThemeProvider children={props.children} theme={theme} />;
-}
+//This returns a ThemeProvider for the main theme that uses the current theme from the provided context
+export const MainThemeProvider: FC<PropsWithChildren> = ({ children }) => {
+  const { theme } = useThemeContext();
+  return <ThemeProvider children={children} theme={theme} />;
+};

--- a/meshapp/src/theme/ThemeContextProvider.tsx
+++ b/meshapp/src/theme/ThemeContextProvider.tsx
@@ -1,0 +1,32 @@
+import { Theme } from "@emotion/react";
+import { PaletteMode, createTheme } from "@mui/material";
+import { FC, PropsWithChildren, createContext, useContext } from "react";
+import { useColorTheme } from "./useColorTheme";
+
+//type of the theme context
+type ThemeContextType = {
+  mode: PaletteMode;
+  toggleThemeMode: () => void;
+  theme: Theme;
+};
+
+//initialization of the context with provided default value
+//the default value provided here doesn't matter as we are passing in the real used value in ThemeContextProvider
+export const ThemeContext = createContext<ThemeContextType>({
+  mode: "light",
+  toggleThemeMode: () => {},
+  theme: createTheme(),
+});
+
+//hook to be used in other components to access theme context
+export const useThemeContext = () => {
+  return useContext(ThemeContext);
+};
+
+//provides context with the actual value from the top level
+export const ThemeContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const value = useColorTheme();
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+};

--- a/meshapp/src/theme/ThemeToggle.tsx
+++ b/meshapp/src/theme/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+import { FormControlLabel, Typography } from "@mui/material";
+import Switch from "@mui/material/Switch";
+import { useEffect, useState } from "react";
+import { text } from "stream/consumers";
+
+/*
+This component returns switch button for enabling/disabling dark mode
+*/
+export default function ThemeToggleSwitch() {
+  //store mode in local storage
+  //if it doesn't exist or is not a valid mode, initalize as light mode
+  let mode = localStorage.getItem("themeMode");
+  if (!mode || (mode !== "light" && mode !== "dark")) {
+    localStorage.setItem("themeMode", "light");
+    mode = "light";
+  }
+
+  //tracks if theme toggle switch is checked or not
+  //checked == dark, not checked == light
+  const [isChecked, setChecked] = useState(mode === "light" ? false : true);
+
+  //handles checking switch, reloads window to apply theme changes
+  const handleChange = () => {
+    setChecked(!isChecked);
+    window.location.reload();
+  };
+
+  //update theme in local storage depending on whether switch is checked
+  useEffect(
+    () => localStorage.setItem("themeMode", isChecked ? "dark" : "light"),
+    [isChecked]
+  );
+
+  return (
+    <FormControlLabel
+      label={<Typography color={"text.primary"}>Enable Dark Mode</Typography>}
+      control={<Switch checked={isChecked} onChange={handleChange} />}
+    />
+  );
+}

--- a/meshapp/src/theme/ThemeToggle.tsx
+++ b/meshapp/src/theme/ThemeToggle.tsx
@@ -1,40 +1,20 @@
 import { FormControlLabel, Typography } from "@mui/material";
 import Switch from "@mui/material/Switch";
-import { useEffect, useState } from "react";
-import { text } from "stream/consumers";
+import { useThemeContext } from "./ThemeContextProvider";
 
-/*
-This component returns switch button for enabling/disabling dark mode
-*/
+//This component returns switch button for enabling/disabling dark mode
 export default function ThemeToggleSwitch() {
-  //store mode in local storage
-  //if it doesn't exist or is not a valid mode, initalize as light mode
-  let mode = localStorage.getItem("themeMode");
-  if (!mode || (mode !== "light" && mode !== "dark")) {
-    localStorage.setItem("themeMode", "light");
-    mode = "light";
-  }
-
-  //tracks if theme toggle switch is checked or not
-  //checked == dark, not checked == light
-  const [isChecked, setChecked] = useState(mode === "light" ? false : true);
-
-  //handles checking switch, reloads window to apply theme changes
-  const handleChange = () => {
-    setChecked(!isChecked);
-    window.location.reload();
-  };
-
-  //update theme in local storage depending on whether switch is checked
-  useEffect(
-    () => localStorage.setItem("themeMode", isChecked ? "dark" : "light"),
-    [isChecked]
-  );
+  const { mode, toggleThemeMode } = useThemeContext();
 
   return (
     <FormControlLabel
       label={<Typography color={"text.primary"}>Enable Dark Mode</Typography>}
-      control={<Switch checked={isChecked} onChange={handleChange} />}
+      control={
+        <Switch
+          checked={mode === "dark" ? true : false}
+          onChange={toggleThemeMode}
+        />
+      }
     />
   );
 }

--- a/meshapp/src/theme/useColorTheme.tsx
+++ b/meshapp/src/theme/useColorTheme.tsx
@@ -1,0 +1,34 @@
+import { PaletteMode } from "@mui/material";
+import { useMemo, useState } from "react";
+import getMainTheme from "./MainTheme";
+
+//this returns the value to be used with the Theme context
+export const useColorTheme = () => {
+  //get stored theme mode, if invalid or undefined initalize current mode and stored theme mode as light mode
+  let storedMode = localStorage.getItem("themeMode");
+  let themeMode: PaletteMode =
+    storedMode && (storedMode === "dark" || storedMode === "light")
+      ? storedMode
+      : "light";
+  if (!storedMode) {
+    localStorage.setItem("themeMode", "light");
+  }
+
+  //stores state of current theme mode
+  const [mode, setMode] = useState<PaletteMode>(themeMode);
+
+  //handles toggling theme mode state and updating local storage theme mode
+  const toggleThemeMode = () => {
+    setMode(mode === "light" ? "dark" : "light");
+    localStorage.setItem("themeMode", mode === "light" ? "dark" : "light");
+  };
+
+  //creates current theme based on current mode
+  const currentTheme = useMemo(() => getMainTheme(mode), [mode]);
+
+  return {
+    theme: currentTheme,
+    mode,
+    toggleThemeMode,
+  };
+};


### PR DESCRIPTION
Implements #118.

# What I've Done
I've created a switch button component that toggles the main theme between light and dark mode. The theme mode is also stored in local storage. If there is no theme mode in local storage, it will be initalized and stored as light mode. I have created a settings route to temporarily contain the toggle button, and I've added the corresponding link to the starting nav. 
I provided context for the theme, current theme mode, and the method used to toggle the theme from the top level, and that context is passed down from the ThemeContextProvider to its descendants, where it's used in the MainThemeProvider and the theme toggle component. 

# What You Should See
The added settings route
![image](https://github.com/LetsMesh/Site/assets/98421648/b4c47016-44fe-432d-aa79-a82846c6cbb2)
The Toggle Theme button at the Settings page
![image](https://github.com/LetsMesh/Site/assets/98421648/9fa7f9d1-db04-4486-b8a6-36a06a1ba3e8)
![image](https://github.com/LetsMesh/Site/assets/98421648/76619797-60f9-4c62-bd30-9c21d4d61932)
The theme mode being changed and stored in response to toggling
![image](https://github.com/LetsMesh/Site/assets/98421648/98daa484-99de-4ef7-8585-04b1a9dc0867)
![image](https://github.com/LetsMesh/Site/assets/98421648/cc6ea847-117c-4965-a7b7-9f238331ce5d)
