### PR TITLE
Hotfix: Profile Tests Missing accountID Attribute

### DIFF
--- a/mesh/profiles/urls.py
+++ b/mesh/profiles/urls.py
@@ -19,8 +19,6 @@ urlpatterns = [
 
     # GET /profiles/user-name/:account_id
     # POST /profiles/user-name/:account_id
-    path("biography/<int:account_id>", profile_views.BiographyView.as_view()),
-    path("profile-picture/<int:account_id>", profile_views.ProfilePicturesView.as_view(), name="profile-picture"),
     path("user-name/<int:account_id>", profile_views.UserNamesView.as_view(), name="user-name"),
     
     # GET /profiles/preferred-name/:account_id

--- a/mesh/profiles/urls.py
+++ b/mesh/profiles/urls.py
@@ -1,4 +1,5 @@
-from django.urls import path, include
+from django.urls import path
+
 from . import views as profile_views
 
 urlpatterns = [
@@ -18,6 +19,8 @@ urlpatterns = [
 
     # GET /profiles/user-name/:account_id
     # POST /profiles/user-name/:account_id
+    path("biography/<int:account_id>", profile_views.BiographyView.as_view()),
+    path("profile-picture/<int:account_id>", profile_views.ProfilePicturesView.as_view(), name="profile-picture"),
     path("user-name/<int:account_id>", profile_views.UserNamesView.as_view(), name="user-name"),
     
     # GET /profiles/preferred-name/:account_id

--- a/meshapp/src/profile/profile-page.tsx
+++ b/meshapp/src/profile/profile-page.tsx
@@ -180,6 +180,7 @@ const ProfileOccupation = (props: {
  *
  * @param props - Properties of the component
  * @param {string} props.biography - The initial text content of the bio
+ * @param {number} props.accountID - accountID associated with the profile
  */
 const ProfileBiography = (props: { biography: string, accountID: number}) => {
 

--- a/meshapp/src/profile/tests/profile-examples.tsx
+++ b/meshapp/src/profile/tests/profile-examples.tsx
@@ -10,6 +10,7 @@ export const exampleProfile: Profile = {
   occupationBusiness: "Self-Employed",
   biography:
     "Self proclaimed narcissist and professional animal petter. A vampire with many years behind me, I have been petting animals for a bagillion years.",
+  accountID: 0,
 };
 
 export const exampleProfile2: Profile = {
@@ -22,4 +23,5 @@ export const exampleProfile2: Profile = {
   occupationBusiness: "Walmart",
   biography:
     "Trained in the art of the blade since being in the womb, became a swordmaster at the age of 3 months, and slayed approximately 4 rats throughout my perilous adventures. Also known as Michael Jackson.",
+  accountID: 1,
 };


### PR DESCRIPTION
Fix for an earlier PR/Merge where I updated the "profile" type to have an accountID attribute.

The example profiles used in the front-end compilation were not updated, and thus would cause compilation/build failures.

I've added the attribute to the tests as a fix while I figure out how/if I will refactor the code.