### PR TITLE
A1.4 Fetch and Display Profile Picture

### DIFF
--- a/mesh/tests/profiles_tests.py
+++ b/mesh/tests/profiles_tests.py
@@ -42,7 +42,7 @@ class ProfilesTest(TestCase):
         test_user = Account.objects.get(email="profilestest@gmail.com")
         response = self.client.get(f"/profiles/profile-picture/{test_user.accountID}")
         json_response = json.loads(response.content.decode("utf-8"))
-        self.assertEquals(json_response.get("data"), {"get": {"profilePicture": "/media/image/profile_test_image.png"}})
+        self.assertEquals(json_response.get("data"), {"get": {"profilePicture": "profile_test_image.png"}})
 
     def test_no_account_profile_picture(self):
         response = self.client.get("/profiles/profile-picture/9999")

--- a/meshapp/src/profile/profile-page.tsx
+++ b/meshapp/src/profile/profile-page.tsx
@@ -79,7 +79,7 @@ const ProfilePage = (props: Profile) => {
             marginBottom: "-125px", // Adjusts container height to match transform
           }}
         >
-          <ProfilePicture image={props.image} />
+          <ProfilePicture image={props.image} accountID={props.accountID}/>
           <ProfileRole isMentor={props.isMentor} isMentee={props.isMentee} />
         </Grid>
       </Grid>

--- a/meshapp/src/profile/profile-picture.tsx
+++ b/meshapp/src/profile/profile-picture.tsx
@@ -18,6 +18,7 @@ import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 import ErrorIcon from "@mui/icons-material/Error";
 
 import "./styling/profile-page.css";
+import { axiosInstance } from "../config/axiosConfig";
 
 const tooltipErrorTheme = createTheme({
   components: {
@@ -40,8 +41,9 @@ const tooltipErrorTheme = createTheme({
  *
  * @param props - Properties of the component
  * @param {string} props.image - A URL to user's profile image
- */
-const ProfilePicture = (props: { image: string }) => {
+ * @param {number} props.accountID - accountID associated with the profile
+*/
+const ProfilePicture = (props: { image: string, accountID: number }) => {
   const [image, setImage] = useState(props.image);
   const [showError, setShowError] = useState(false);
 
@@ -50,6 +52,18 @@ const ProfilePicture = (props: { image: string }) => {
     setOpen(false);
     setShowError(false);
   };
+
+  // Gets the user's profile picture and saves it to the display image
+  React.useEffect(() => {
+    axiosInstance.get("profiles/profile-picture/" + props.accountID)
+    .then(response => {
+      console.log(response)
+      setImage(response.data["data"]["get"]["profilePicture"])
+    })
+    .catch(error => {
+      console.error(error)
+    })
+  }, [])
 
   return (
     <Box


### PR DESCRIPTION
Resolves #4 

The ProfilePicture component now passes down the accountID as a prop, which is used in the AXIOS GET call to retrieve and display the profile picture.

I've modified the profile picture test case to reflect the expected GET response.