### PR TITLE
Leaf/b3.1 2 factor account setting

### DIFF
--- a/mesh/accountSettings/urls.py
+++ b/mesh/accountSettings/urls.py
@@ -3,5 +3,8 @@ from . import views as accountsettings_views
 
 urlpatterns = [
     path("displayTheme", accountsettings_views.display_theme, name="display_theme"),
-    path("settings", accountsettings_views.showSettings.as_view(), name="settings")
+
+    # GET    /api/settings/:account_id
+    # PATCH  /api/settings/:account_id
+    path("settings/<int:account_id>", accountsettings_views.showSettings.as_view(), name="settings")
 ]

--- a/mesh/accountSettings/urls.py
+++ b/mesh/accountSettings/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views as accountsettings_views
 
 urlpatterns = [
-    path("displayTheme", accountsettings_views.display_theme, name="display_theme")
+    path("displayTheme", accountsettings_views.display_theme, name="display_theme"),
+    path("twoFactAuth", accountsettings_views.two_fact_auth, name="two_fact_auth")
 ]

--- a/mesh/accountSettings/urls.py
+++ b/mesh/accountSettings/urls.py
@@ -3,5 +3,5 @@ from . import views as accountsettings_views
 
 urlpatterns = [
     path("displayTheme", accountsettings_views.display_theme, name="display_theme"),
-    path("twoFactAuth", accountsettings_views.two_fact_auth, name="two_fact_auth")
+    path("twoFactAuth", accountsettings_views.TwoFactAuthView.two_fact_auth, name="two_fact_auth")
 ]

--- a/mesh/accountSettings/urls.py
+++ b/mesh/accountSettings/urls.py
@@ -3,5 +3,5 @@ from . import views as accountsettings_views
 
 urlpatterns = [
     path("displayTheme", accountsettings_views.display_theme, name="display_theme"),
-    path("twoFactAuth", accountsettings_views.TwoFactAuthView.two_fact_auth, name="two_fact_auth")
+    path("settings", accountsettings_views.showSettings.as_view(), name="settings")
 ]

--- a/mesh/accountSettings/views.py
+++ b/mesh/accountSettings/views.py
@@ -68,12 +68,12 @@ class showSettings(View):
         try:
             settings = Settings.objects.get(accountID=account_id)
             data = json.loads(request.body)
-            settings.accountID = data.get('accountID', settings)
-            settings.isVerified = data.get('isVerified', settings)
-            settings.verificationToken = data.get('verificationToken', settings)
-            settings.hasContentFilterEnabled = data.get('hasContentFilterEnabled', settings)
-            settings.displayTheme = data.get('displayTheme', settings)
-            settings.is2FAEnabled = data.get('is2FAEnabled', settings)
+            settings.accountID = data.get('accountID')
+            settings.isVerified = data.get('isVerified')
+            settings.verificationToken = data.get('verificationToken')
+            settings.hasContentFilterEnabled = data.get('hasContentFilterEnabled')
+            settings.displayTheme = data.get('displayTheme')
+            settings.is2FAEnabled = data.get('is2FAEnabled')
             settings.save()
             return HttpResponse(status=204)
         except Account.DoesNotExist:

--- a/mesh/accountSettings/views.py
+++ b/mesh/accountSettings/views.py
@@ -68,7 +68,7 @@ class showSettings(View):
         try:
             settings = Settings.objects.get(accountID=account_id)
             data = json.loads(request.body)
-            settings.accountID = data.get('accountID')
+            settings.accountID = Account.objects.get(accountID=data.get('accountID'))
             settings.isVerified = data.get('isVerified')
             settings.verificationToken = data.get('verificationToken')
             settings.hasContentFilterEnabled = data.get('hasContentFilterEnabled')

--- a/mesh/accountSettings/views.py
+++ b/mesh/accountSettings/views.py
@@ -34,7 +34,7 @@ def display_theme(request):
                 response.update({"message": "An account does not exist with this account ID."})
                 return JsonResponse(response)
 
-class TwoFactAuthView(View):
+class showSettings(View):
     """ 
     Handles HTTP requests related to Two Factor Authentication account settings.
     Support Get request to retrieve setting and patch to change setting.
@@ -47,8 +47,8 @@ class TwoFactAuthView(View):
         Returns a 404 error with error message if account does not exist.
         """
         try:
-            settings_2FactAuth = Settings.objects.get(accountID=account_id).is2FAEnabled
-            settings_detail = serializers.serialize('json', [settings_2FactAuth])
+            settings = Settings.objects.get(accountID=account_id)
+            settings_detail = serializers.serialize('json', [settings])
             return JsonResponse(settings_detail, safe=False)
         except Account.DoesNotExist:
             return JsonResponse({'error': 'An account does not exist with this account ID.'}, status=404)
@@ -68,7 +68,12 @@ class TwoFactAuthView(View):
         try:
             settings = Settings.objects.get(accountID=account_id)
             data = json.loads(request.body)
-            settings.is2FAEnabled = data.get('is2FAEnabled', settings.is2FAEnabled)
+            settings.accountID = data.get('accountID', settings)
+            settings.isVerified = data.get('isVerified', settings)
+            settings.verificationToken = data.get('verificationToken', settings)
+            settings.hasContentFilterEnabled = data.get('hasContentFilterEnabled', settings)
+            settings.displayTheme = data.get('displayTheme', settings)
+            settings.is2FAEnabled = data.get('is2FAEnabled', settings)
             settings.save()
             return HttpResponse(status=204)
         except Account.DoesNotExist:

--- a/mesh/accountSettings/views.py
+++ b/mesh/accountSettings/views.py
@@ -1,5 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
+from django.views import View
+from django.core import serializers
 
 from mesh.accountSettings.models import Settings
 
@@ -29,3 +31,32 @@ def display_theme(request):
                 response.update({"status": "error"})
                 response.update({"message": "An account does not exist with this account ID."})
                 return JsonResponse(response)
+
+class TwoFactAuthView(View):
+    """ 
+    Handles HTTP requests related to Two Factor Authentication account settings.
+    Support Get request to retrieve setting and patch to change setting.
+    """
+    def get(self, request, account_id, *args, **kwargs):
+        """ 
+        Handles GET request
+
+        Return JSON with Two Factor Authentication Settings for given account ID. 
+        Returns a 404 error with error message if account does not exist.
+        """
+        try:
+            settings_2FactAuth = Settings.objects.get(accountID=account_id).is2FAEnabled
+            settings_detail = serializers.serialize('json', [settings_2FactAuth])
+            return JsonResponse(settings_detail, safe=False)
+        except ObjectDoesNotExist:
+            return JsonResponse({'error': 'An account does not exist with this account ID.'}, status=404)
+
+    
+    def patch():
+        """ 
+        Handles Patch request
+        
+        t
+        """
+        
+

--- a/mesh/settings.py
+++ b/mesh/settings.py
@@ -12,9 +12,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/mesh/settings.py
+++ b/mesh/settings.py
@@ -46,8 +46,8 @@ INSTALLED_APPS = [
     'mesh.conversation',
     'mesh.notifications',
     'mesh.tags',
-    'mesh.occupations'
-    
+    'mesh.occupations',
+    'corsheaders',
 ]
 
 # TODO: https://github.com/LetsMesh/Site/issues/202
@@ -55,11 +55,16 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ALLOWED_HOSTS=[
+    
 ]
 
 CORS_ORIGIN_WHITELIST = [

--- a/mesh/tests/settings_tests.py
+++ b/mesh/tests/settings_tests.py
@@ -9,7 +9,7 @@ from mesh.accounts.models import Account
 class SettingsTest(TestCase):
     def setUp(self):
         self.client = Client()
-        test_account = Account.objects.create(
+        self.test_account = Account.objects.create(
             email="settingstest@gmail.com",
             encryptedPass=bytes("password_test", "utf-8"),
             phoneNum="1234567890",
@@ -19,7 +19,7 @@ class SettingsTest(TestCase):
             isMentee=True
         )
         Settings.objects.create(
-            accountID=test_account,
+            accountID=self.test_account,
             isVerified=False,
             verificationToken=None,
             hasContentFilterEnabled=False,
@@ -52,23 +52,26 @@ class SettingsTest(TestCase):
         """
         Test case to see if settings are retrieved from account settings
 
-        GET request to /accountSettings/settings endpoint.
+        GET request to /settings/settings endpoint.
         Test passes if 200 response status code is returned
         """
         test_user = Account.objects.get(email="settingstest@gmail.com")
-        response = self.client.get(f"/settings/{test_user.accountID}/")
+        response = self.client.get(f"/settings/settings/{test_user.accountID}/")
         self.assertEqual(response.status_code, 200)
 
-    '''def test_update_settings(self):
+    def test_update_settings(self):
         """
         Test case to see if settings are patched or update to account settings
 
-        Patch request to /accountSettings/settings endpoint.
-        Test passes if 200 response status code is returned
+        Patch request to /settings/settings endpoint.
+        Test passes if 204 response status code is returned
         """
-        test_user_settings = Settings.objects.get(email="settingstest@gmail.com")
+        test_user = Account.objects.get(email="settingstest@gmail.com")
+        test_user_settings = Settings.objects.get(accountID=test_user)
 
-        new_account_data = {
+        print(f"Test User: {test_user}")
+
+        updated_account_data = {
             "accountID": test_user,
             "isVerified": False,
             "verificationToken": None,
@@ -77,10 +80,16 @@ class SettingsTest(TestCase):
             "is2FAEnabled": False,
         }
 
-        """ json_response = json.loads(response.content.decode("utf-8")) """
-        self.assertEqual(test_user_settings.accountID, )
-        self.assertEqual(test_user_settings.isVerified, )
-        self.assertEqual(test_user_settings.verificationToken, )
-        self.assertEqual(test_user_settings.hasContentFilterEnabled, )
-        self.assertEqual(test_user_settings.displayTheme, )
-        self.assertEqual(test_user_settings.is2FAEnabled, )'''
+        json_data = json.dumps(updated_account_data, default=str)
+
+        response = self.client.patch(f'/settings/settings/{test_user_settings.accountID}/', json_data, content_type='application/json')
+        self.assertEqual(response.status_code, 204)
+
+        updated_test_user = Account.objects.get(email="settingstest@gmail.com")
+        updated_test_user_settings = Settings.objects.get(accountID=updated_test_user)
+        self.assertEqual(updated_test_user_settings.accountID, updated_account_data['accountID'])
+        self.assertEqual(updated_test_user_settings.isVerified, updated_account_data['isVerified'])
+        self.assertEqual(updated_test_user_settings.verificationToken, updated_account_data['verificationToken'])
+        self.assertEqual(updated_test_user_settings.hasContentFilterEnabled, updated_account_data['hasContentFilterEnabled'])
+        self.assertEqual(updated_test_user_settings.displayTheme, updated_account_data['displayTheme'])
+        self.assertEqual(updated_test_user_settings.is2FAEnabled, updated_account_data['is2FAEnabled'])

--- a/mesh/tests/settings_tests.py
+++ b/mesh/tests/settings_tests.py
@@ -44,3 +44,43 @@ class SettingsTest(TestCase):
         json_response = json.loads(response.content.decode("utf-8"))
         self.assertEquals(json_response.get("status"), "error")
         self.assertEquals(json_response.get("message"), "An account does not exist with this account ID.")
+
+    """
+    Settings Testing
+    """
+    def test_get_settings(self):
+        """
+        Test case to see if settings are retrieved from account settings
+
+        GET request to /accountSettings/settings endpoint.
+        Test passes if 200 response status code is returned
+        """
+        test_user = Account.objects.get(email="settingstest@gmail.com")
+        response = self.client.get(f"/settings/{test_user.accountID}/")
+        self.assertEqual(response.status_code, 200)
+
+    '''def test_update_settings(self):
+        """
+        Test case to see if settings are patched or update to account settings
+
+        Patch request to /accountSettings/settings endpoint.
+        Test passes if 200 response status code is returned
+        """
+        test_user_settings = Settings.objects.get(email="settingstest@gmail.com")
+
+        new_account_data = {
+            "accountID": test_user,
+            "isVerified": False,
+            "verificationToken": None,
+            "hasContentFilterEnabled": False,
+            "displayTheme": "0",
+            "is2FAEnabled": False,
+        }
+
+        """ json_response = json.loads(response.content.decode("utf-8")) """
+        self.assertEqual(test_user_settings.accountID, )
+        self.assertEqual(test_user_settings.isVerified, )
+        self.assertEqual(test_user_settings.verificationToken, )
+        self.assertEqual(test_user_settings.hasContentFilterEnabled, )
+        self.assertEqual(test_user_settings.displayTheme, )
+        self.assertEqual(test_user_settings.is2FAEnabled, )'''

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -1,52 +1,56 @@
-import React, { useState, useEffect } from "react";
-import { 
-    Divider, 
-    FormGroup, 
-    FormControlLabel, 
-    Switch, 
-    Typography } 
-    from "@mui/material";
+import React, { useState, useEffect } from 'react';
+import { Switch, FormControlLabel, Container, Typography } from '@mui/material';
 
-import { AccountSettings } from "./types/account-settings";
+//import { AccountSettings } from "./types/account-settings";
+import { axiosInstance } from "../config/axiosConfig";
 
-/** 
- * React component that renders the settings page
- * Displays settings that are set by the user for their account
- * 
- * @param props - Properties of component
- * @param {number} props.accountID - user accoutn ID
- * @param {boolean} props.isVerified - flag to check if user is verified
- * @param {string} props.verificationToken - token for verification
- * @param {boolean} props.hasContentFilterEnabled - flag to check if content is filtered
- * @param {number} props.displayTheme - display theme
- * @param {boolean} props.is2FAEnabled - flag to check if user is registered for 2FactAuth
- */ 
-export default function Settings(props: AccountSettings) {
-    return (
-        <Divider>
-            <Typography variant="h2" textAlign={"left"}>
-                Settings
-            </Typography>
-            <Divider>
-                <TwoFactorAuth is2FAEnabled={props.is2FAEnabled}/>
-            </Divider>
-        </Divider>
-    )
-};
+const SettingSwitch = (label: any, value: any, onChange: any) => {
+  return (
+    <FormControlLabel
+      control={<Switch checked={value} onChange={onChange} />}
+      label={label}
+    />
+  );
+}
 
-/**
- * Display user's 2FactAuth setting 
- * 
- * @param props - Properties of component
- * @param {boolean} props.is2FAEnabled - flag to check if user is registered for 2FactAuth
- */
-const TwoFactorAuth = (props: { is2FAEnabled: boolean }) => { 
-    const {is2FAEnabled} = props
-    return (
-        <Divider>
-            <FormGroup>
-                    <FormControlLabel control={is2FAEnabled ? <Switch defaultChecked/> : <Switch />} label="2 Factor Authentication: " /> 
-            </FormGroup>
-        </Divider>
-    )
+export default function SettingsPage() {
+  const [settings, setSettings] = useState({
+    isVerified: false,
+    is2FAEnabled: false
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleToggleChange = (settingName: any) => (event: any) => {
+    setSettings({ ...settings, [settingName]: event.target.checked });
+  };
+
+  useEffect(() => {
+    // Make a GET request to the backend API to retrieve account settings
+    axiosInstance.get('/accountSettings/twoFactAuth')
+      .then((response) => {
+        setSettings(response.data);
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error('Error fetching account settings:', error);
+        setLoading(false);
+      });
+  }, []); // Empty dependency array to run the effect once when the component mounts
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>
+        Account Settings
+      </Typography>
+      <SettingSwitch
+        label="Enable Two Factor Authentication"
+        value={settings.is2FAEnabled}
+        onChange={handleToggleChange('is2FAEnabled')}
+      /> 
+    </Container>
+  );
 }

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -7,24 +7,45 @@ import {
     Typography } 
     from "@mui/material";
 
-export default function Settings() {
+import { AccountSettings } from "./types/account-settings";
+
+/** 
+ * React component that renders the settings page
+ * Displays settings that are set by the user for their account
+ * 
+ * @param props - Properties of component
+ * @param {number} props.accountID - user accoutn ID
+ * @param {boolean} props.isVerified - flag to check if user is verified
+ * @param {string} props.verificationToken - token for verification
+ * @param {boolean} props.hasContentFilterEnabled - flag to check if content is filtered
+ * @param {number} props.displayTheme - display theme
+ * @param {boolean} props.is2FAEnabled - flag to check if user is registered for 2FactAuth
+ */ 
+export default function Settings(props: AccountSettings) {
     return (
         <Divider>
             <Typography variant="h2" textAlign={"left"}>
                 Settings
             </Typography>
             <Divider>
-                <TwoFactorAuth />
+                <TwoFactorAuth is2FAEnabled={props.is2FAEnabled}/>
             </Divider>
         </Divider>
     )
 };
 
-const TwoFactorAuth = () => {
+/**
+ * Display user's 2FactAuth setting 
+ * 
+ * @param props - Properties of component
+ * @param {boolean} props.is2FAEnabled - flag to check if user is registered for 2FactAuth
+ */
+const TwoFactorAuth = (props: { is2FAEnabled: boolean }) => { 
+    const {is2FAEnabled} = props
     return (
         <Divider>
             <FormGroup>
-                <FormControlLabel control={<Switch />} label="2 Factor Authentication" />
+                    <FormControlLabel control={is2FAEnabled ? <Switch defaultChecked/> : <Switch />} label="2 Factor Authentication: " /> 
             </FormGroup>
         </Divider>
     )

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -4,29 +4,35 @@ import { Switch, FormControlLabel, Container, Typography } from '@mui/material';
 //import { AccountSettings } from "./types/account-settings";
 import { axiosInstance } from "../config/axiosConfig";
 
-function SettingSwitch(label: any, value: any, onChange: any) {
+interface SettingsProps {
+  value: any,
+  label: string,
+  onChange: (event: any) => void,
+}
+
+const SettingSwitch = (props: SettingsProps) => {
   return (
     <FormControlLabel
-      control={<Switch checked={value} onChange={onChange} />}
-      label={label}
+      control={<Switch checked={props.value} onChange={props.onChange} />}
+      label={props.label}
     />
   );
 }
 
-export default function SettingsPage() {
+const SettingsPage = () => {
   const [settings, setSettings] = useState({
     //isVerified: false,
     is2FAEnabled: false
   });
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   const handleToggleChange = (settingName: any) => (event: any) => {
     setSettings({ ...settings, [settingName]: event.target.checked });
   };
 
-  useEffect(() => {
+  /* useEffect(() => {
     // Make a GET request to the backend API to retrieve account settings
-    axiosInstance.get('/accountSettings/twoFactAuth')
+    axiosInstance.get('/accountSettings/settings')
       .then((response) => {
         setSettings(response.data);
         setLoading(false);
@@ -35,7 +41,7 @@ export default function SettingsPage() {
         console.error('Error fetching account settings:', error);
         setLoading(true);
       });
-  }, []); // Empty dependency array to run the effect once when the component mounts
+  }, []); // Empty dependency array to run the effect once when the component mounts */
 
   if (loading) {
     return <div>Loading...</div>;
@@ -54,3 +60,5 @@ export default function SettingsPage() {
     </Container>
   );
 }
+
+export default SettingsPage;

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -1,8 +1,24 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, FormControlLabel, Container, Typography } from '@mui/material';
+import { Switch, FormControlLabel, Container, Typography, createTheme, ThemeProvider } from '@mui/material';
 
 import { AccountSettings } from "./types/account-settings"
 import { axiosInstance } from "../config/axiosConfig";
+
+const theme = createTheme({
+  palette: {
+    mode: "light",
+    primary: {
+      main: "#1cba9a",
+    },
+  },
+  typography: {
+    h1: {
+      fontFamily: "cocogoose",
+      fontWeight: "bold",
+      color: "#ffffff",
+    },
+  },
+}); 
 
 interface SettingsProps {
   value: any,
@@ -10,15 +26,36 @@ interface SettingsProps {
   onChange: (event: any) => void,
 }
 
+/**
+ * React component that represents a single setting
+ * Represented through a React Switch
+ * 
+ * @param props - properties of the component
+ */
 const SettingSwitch = (props: SettingsProps) => {
   return (
-    <FormControlLabel
+    <ThemeProvider theme={theme}>
+      <FormControlLabel
       control={<Switch checked={props.value} onChange={props.onChange} />}
-      label={props.label}
-    />
+      label={<span style={{ color: 'white' }}>{props.label}</span>}
+      />
+    </ThemeProvider>
   );
 }
 
+/**
+ * React component to render settings page.
+ * Displays setting options for the account.
+ * 
+ * @param props 
+ * @param {number} props.accountID - ID for account that settings represent
+ * @param {boolean} props.isVerified - flag for is account if verified
+ * @param {string} props.verificationToken - Token for verification
+ * @param {boolean} props.hasContentFilterEnabled - flag for content filtering
+ * @param {char} props.displayTheme - Char for display theme
+ * @param {boolean} props.is2FAEnabled - flag for if account has TwoFactorAuthentication is enabled
+ * 
+ */
 const SettingsPage = (props: AccountSettings) => {
   const [settings, setSettings] = useState({
     accountID: props.accountID,
@@ -47,15 +84,19 @@ const SettingsPage = (props: AccountSettings) => {
         console.error('Error patching account settings:', error);
         setLoading(true);
       });
-  }, []); // Empty dependency array to run the effect once when the component mounts 
+  }, []); 
 
+  /** 
+   *  NOTE: Second useEffect for sending patch request to update account settings each time settings is modified.
+   *        The patch request is made every time the setting switch is changed.
+   *        This may want to be changed in the future to ensure that only one 
+   *        patch request is made for multiple settings.
+   */
   useEffect(() => {
-    // Make a PATCH request to the backend API to update account settings
+    // Make a PATCH request to the backend API to update account settings 
     axiosInstance.patch("settings/settings/" + props.accountID + "/", {...settings}) // NOTE: Use accountSettings api name when merging
-      .then((response) => {
-        console.log("Patch Response: " + response)
+      .then(() => {
         setLoading(false);
-        console.log("After Set: " + settings.is2FAEnabled)
       })
       .catch((error) => {
         console.error('Error patching account settings:', error);
@@ -64,8 +105,7 @@ const SettingsPage = (props: AccountSettings) => {
   }, [settings])
 
   const handleToggleChange = (settingName: any) => (event: any) => {
-    console.log("Before Set: " + settings.is2FAEnabled)
-    setSettings({ ...settings, [settingName]: event.target.checked });
+    setSettings({ ...settings, [settingName]: event.target.checked }); // TODO: Implement Confirm Authentication for 2FactAuth
   };
 
   if (loading) {
@@ -74,7 +114,7 @@ const SettingsPage = (props: AccountSettings) => {
 
   return (
     <Container>
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="h4" color="white" gutterBottom>
         Account Settings
       </Typography>
       <SettingSwitch

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -4,7 +4,7 @@ import { Switch, FormControlLabel, Container, Typography } from '@mui/material';
 //import { AccountSettings } from "./types/account-settings";
 import { axiosInstance } from "../config/axiosConfig";
 
-const SettingSwitch = (label: any, value: any, onChange: any) => {
+function SettingSwitch(label: any, value: any, onChange: any) {
   return (
     <FormControlLabel
       control={<Switch checked={value} onChange={onChange} />}
@@ -15,10 +15,10 @@ const SettingSwitch = (label: any, value: any, onChange: any) => {
 
 export default function SettingsPage() {
   const [settings, setSettings] = useState({
-    isVerified: false,
+    //isVerified: false,
     is2FAEnabled: false
   });
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const handleToggleChange = (settingName: any) => (event: any) => {
     setSettings({ ...settings, [settingName]: event.target.checked });
@@ -33,7 +33,7 @@ export default function SettingsPage() {
       })
       .catch((error) => {
         console.error('Error fetching account settings:', error);
-        setLoading(false);
+        setLoading(true);
       });
   }, []); // Empty dependency array to run the effect once when the component mounts
 

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from "react";
+import { 
+    Divider, 
+    FormGroup, 
+    FormControlLabel, 
+    Switch, 
+    Typography } 
+    from "@mui/material";
+
+export default function Settings() {
+    return (
+        <Divider>
+            <Typography variant="h2" textAlign={"left"}>
+                Settings
+            </Typography>
+            <Divider>
+                <TwoFactorAuth />
+            </Divider>
+        </Divider>
+    )
+};
+
+const TwoFactorAuth = () => {
+    return (
+        <Divider>
+            <FormGroup>
+                <FormControlLabel control={<Switch />} label="2 Factor Authentication" />
+            </FormGroup>
+        </Divider>
+    )
+}

--- a/meshapp/src/Settings/settings-page.tsx
+++ b/meshapp/src/Settings/settings-page.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Switch, FormControlLabel, Container, Typography } from '@mui/material';
 
-//import { AccountSettings } from "./types/account-settings";
+import { AccountSettings } from "./types/account-settings"
 import { axiosInstance } from "../config/axiosConfig";
 
 interface SettingsProps {
@@ -19,29 +19,54 @@ const SettingSwitch = (props: SettingsProps) => {
   );
 }
 
-const SettingsPage = () => {
+const SettingsPage = (props: AccountSettings) => {
   const [settings, setSettings] = useState({
-    //isVerified: false,
+    accountID: props.accountID,
+    isVerified: props.isVerified,
+    verificationToken: props.verificationToken,
+    hasContentFilterEnabled: props.hasContentFilterEnabled,
+    displayTheme: props.displayTheme,
     is2FAEnabled: false
   });
   const [loading, setLoading] = useState(false);
 
-  const handleToggleChange = (settingName: any) => (event: any) => {
-    setSettings({ ...settings, [settingName]: event.target.checked });
-  };
-
-  /* useEffect(() => {
-    // Make a GET request to the backend API to retrieve account settings
-    axiosInstance.get('/accountSettings/settings')
+  useEffect(() => {
+    // Make a GET request to update the settings page with user settings
+    axiosInstance.get("settings/settings/" + props.accountID + "/")   // NOTE: settings/settings is old api, use accountSettings when merging
       .then((response) => {
-        setSettings(response.data);
         setLoading(false);
+        let settingsData = JSON.parse(response.data)[0]["fields"]
+        setSettings({...settings, 
+          isVerified: settingsData.isVerified,
+          verificationToken: settingsData.verificationToken,
+          hasContentFilterEnabled: settingsData.hasContentFilterEnabled,
+          displayTheme: settingsData.displayTheme,
+          is2FAEnabled: settingsData.is2FAEnabled});
       })
       .catch((error) => {
-        console.error('Error fetching account settings:', error);
+        console.error('Error patching account settings:', error);
         setLoading(true);
       });
-  }, []); // Empty dependency array to run the effect once when the component mounts */
+  }, []); // Empty dependency array to run the effect once when the component mounts 
+
+  useEffect(() => {
+    // Make a PATCH request to the backend API to update account settings
+    axiosInstance.patch("settings/settings/" + props.accountID + "/", {...settings}) // NOTE: Use accountSettings api name when merging
+      .then((response) => {
+        console.log("Patch Response: " + response)
+        setLoading(false);
+        console.log("After Set: " + settings.is2FAEnabled)
+      })
+      .catch((error) => {
+        console.error('Error patching account settings:', error);
+        setLoading(true);
+      });
+  }, [settings])
+
+  const handleToggleChange = (settingName: any) => (event: any) => {
+    console.log("Before Set: " + settings.is2FAEnabled)
+    setSettings({ ...settings, [settingName]: event.target.checked });
+  };
 
   if (loading) {
     return <div>Loading...</div>;

--- a/meshapp/src/Settings/tests/settings-examples.tsx
+++ b/meshapp/src/Settings/tests/settings-examples.tsx
@@ -1,0 +1,10 @@
+import { AccountSettings } from "../types/account-settings"
+
+export const exampleSettings: AccountSettings = {
+    accountID: 2,
+    isVerified: false,
+    verificationToken: "",
+    hasContentFilterEnabled: false,
+    displayTheme: 0,
+    is2FAEnabled: true,
+}

--- a/meshapp/src/Settings/types/account-settings.d.ts
+++ b/meshapp/src/Settings/types/account-settings.d.ts
@@ -1,0 +1,8 @@
+export type AccountSettings = {
+    accountID: number;
+    isVerified: boolean;
+    verificationToken: string;
+    hasContentFilterEnabled: boolean; 
+    displayTheme: number; 
+    is2FAEnabled: boolean;
+};

--- a/meshapp/src/Settings/types/account-settings.d.ts
+++ b/meshapp/src/Settings/types/account-settings.d.ts
@@ -3,6 +3,6 @@ export type AccountSettings = {
     isVerified: boolean;
     verificationToken: string;
     hasContentFilterEnabled: boolean; 
-    displayTheme: number; 
+    displayTheme: char; 
     is2FAEnabled: boolean;
 };

--- a/meshapp/src/index.tsx
+++ b/meshapp/src/index.tsx
@@ -31,7 +31,7 @@ root.render(
       <ProfilePage {...exampleProfile} />
       <LoggedInHome />    
       <SignUp />
-      <Settings />
+      <Settings /> 
     </ThemeProvider>
   </React.StrictMode>
 );

--- a/meshapp/src/index.tsx
+++ b/meshapp/src/index.tsx
@@ -17,6 +17,7 @@ import {
   exampleProfile,
   exampleProfile2,
 } from "./profile/tests/profile-examples";
+import { exampleSettings } from "./Settings/tests/settings-examples";
 import SignUp from "./components/SignUp/SignUp";
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 root.render(
@@ -31,7 +32,7 @@ root.render(
       <ProfilePage {...exampleProfile} />
       <LoggedInHome />    
       <SignUp />
-      <Settings /> 
+      <Settings {...exampleSettings}/> 
     </ThemeProvider>
   </React.StrictMode>
 );

--- a/meshapp/src/index.tsx
+++ b/meshapp/src/index.tsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from "@emotion/react";
 import ProfilePage from "./profile/profile-page";
 import ForgotPassword from "./components/password-forms/forgot-password-form"
 import LoggedInHome from "./home/logged-in/LoggedInHome";
+import Settings from "./Settings/settings-page"
 
 import {
   exampleProfile,
@@ -30,6 +31,7 @@ root.render(
       <ProfilePage {...exampleProfile} />
       <LoggedInHome />    
       <SignUp />
+      <Settings />
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Settings page with setting options for the user account.

- Toggle settings for user account (currently only 2FactAuth)
- Saves settings options and is displayed when settings page is built 

Todo:

- Need to confirm 2FactAuth Settings with email
- Styling is basic, may want to create better visual aesthetics with color and spacing
- New Toggle components needed for other settings with non-boolean values