### PR TITLE
Leaf/ci django

### DIFF
--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -27,11 +27,11 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pipenv
-          pipenv install
+          cache: "pipenv"
+      - name: Install pipenv
+        run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      - name: Install dependencies
+        run: pipenv install
       - name: Run Tests
         env:
           DB_HOST: 127.0.0.1

--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -11,6 +11,16 @@ jobs:
       matrix:
         python-version: [3.11]
 
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: testrootpass
+          MYSQL_DATABASE: github-actions
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -23,5 +33,12 @@ jobs:
           pip install pipenv
           pipenv install
       - name: Run Tests
+        env:
+          DB_HOST: 127.0.0.1
+          DB_NAME: github-actions
+          DB_USER: root
+          DB_PASS: testrootpass
         run: |
+          # Apply migrations and run tests
+          pipenv run python manage.py migrate
           pipenv run python manage.py test --pattern="*_tests.py"

--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -38,6 +38,7 @@ jobs:
           DB_NAME: github-actions
           DB_USER: root
           DB_PASS: testrootpass
+          API_SECRET_KEY: testsecretkey
         run: |
           # Apply migrations and run tests
           pipenv run python manage.py migrate

--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -1,0 +1,27 @@
+name: Django CI
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.11]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+          pipenv install
+      - name: Run Tests
+        run: |
+          pipenv run python manage.py test --pattern="*_tests.py"

--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -2,6 +2,15 @@ name: Django CI
 
 on:
   push:
+    paths:
+      [
+        "mesh/**",
+        "manage.py",
+        "Pipfile",
+        "Pipfile.lock",
+        ".github/workflows/**",
+      ]
+  pull_request:
 
 jobs:
   build:
@@ -19,7 +28,7 @@ jobs:
           MYSQL_DATABASE: github-actions
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
 
     steps:
       - uses: actions/checkout@v4

--- a/mesh/settings.py
+++ b/mesh/settings.py
@@ -157,7 +157,7 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'meshapp/build/static')
+    # os.path.join(BASE_DIR, 'meshapp/build/static')
 ]
 
 CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
This will run django tests on every push related to backend (pip files, `manage.py` and `/mesh` folder) and every pull requests (targets can be changed)

Currently, the setup will run every test on the folder `/mesh/tests/` that ends with `_tests.py` 

- Modified `settings.py`: according to what I can look up online, `STATICFILES_DIRS` in `settings.py` is used to define additional directories where Django should look for static files (CSS, JavaScript, images, etc.) during the static file collection process. This might not be necessary as we're only using Django for backend API (correct me if I'm wrong), so uncomment this might not affect our current project setup.